### PR TITLE
A possible implementation for updating Eplus session for every 20-40 min

### DIFF
--- a/eplus.py
+++ b/eplus.py
@@ -133,7 +133,7 @@ class EplusHLSStreamWorker(HLSStreamWorker):
             else:
                 log.debug(f'[ipid] [EplusHLSStreamWorker] Playlist unchanged but threshold does not exceed. current_time = {current_time}, self._first_playlist_unchanged = {self._first_playlist_unchanged}')
         else:
-            # If playlost changed, reset first_playlist_unchanged.
+            # If playlist changed, reset first_playlist_unchanged.
             self._first_playlist_unchanged = None
 
         return reload_result

--- a/eplus.py
+++ b/eplus.py
@@ -62,7 +62,7 @@ class EplusSessionUpdater(Thread):
                 return
 
             # Create a new session, and send a request to Eplus url to obtain the cookies4
-            log.info('[EplusSessionUpdater] Refreshing cookies...')
+            log.debug('[EplusSessionUpdater] Refreshing cookies...')
             fresh_response = self._session.http.get(self._eplus_url, headers={
                 'Cookie': ''
             })
@@ -70,7 +70,7 @@ class EplusSessionUpdater(Thread):
             # Update the session with the new cookies
             self._session.http.cookies.clear()
             self._session.http.cookies.update(fresh_response.cookies)
-            log.info(f'[EplusSessionUpdater] Successfully updated cookies: Got {len(fresh_response.cookies)} cookies')
+            log.debug(f'[EplusSessionUpdater] Successfully updated cookies: <{repr(fresh_response.cookies)}>')
 
             self.wait_for_about_half_hour()
 
@@ -81,7 +81,9 @@ class EplusSessionUpdater(Thread):
 
         e.g. To avoid multiple people visiting Eplus at the same time, a random interval is used.
         """
-        self._closed.wait(random.randint(20 * 60, 40 * 60))
+        wait_sec = random.randint(20 * 60, 40 * 60)
+        log.debug(f'[EplusSessionUpdater] Will update again after {wait_sec // 60}m {wait_sec % 60}s')
+        self._closed.wait(wait_sec)
 
 
 class EplusHLSStreamWorker(HLSStreamWorker):

--- a/eplus.py
+++ b/eplus.py
@@ -120,6 +120,7 @@ class EplusHLSStreamWorker(HLSStreamWorker):
         reload_result = self._reload_playlist_helper()
         log.debug(f'[ipid] [EplusHLSStreamWorker] Playlist reloaded. self.playlist_changed = {self.playlist_changed}, _first_playlist_unchanged = {self._first_playlist_unchanged}')
         if not self.playlist_changed:
+            # If playlist unchanged, check if the stream is actually ended.
             current_time = get_timestamp_second()
             if self._first_playlist_unchanged is None:
                 self._first_playlist_unchanged = current_time
@@ -131,6 +132,9 @@ class EplusHLSStreamWorker(HLSStreamWorker):
                 self.close()
             else:
                 log.debug(f'[ipid] [EplusHLSStreamWorker] Playlist unchanged but threshold does not exceed. current_time = {current_time}, self._first_playlist_unchanged = {self._first_playlist_unchanged}')
+        else:
+            # If playlost changed, reset first_playlist_unchanged.
+            self._first_playlist_unchanged = None
 
         return reload_result
 


### PR DESCRIPTION
I recently tried your awesome plugin to watch and re-stream the eplus live stream.

It works great! However, it seems that even though `reload_playlist` is implemented in the plugin, the live stream still breaks for every 60 minutes due to expiration of eplus cookies. That's why I tried to write an `EplusSessionUpdater` class, which starts a new thread and fetches new cookies every 20-40 minutes.

The class' goal is to get cookies without breaking the current live stream. However, the code lacks thread-safe assurance and is possibly unstable. Do you have better idea to update new cookies?