### PR TITLE
eplus: auto refresh cookies before expiration (rewrite)

### DIFF
--- a/eplus.py
+++ b/eplus.py
@@ -54,7 +54,7 @@ class EplusSessionUpdater(Thread):
         self._last_expire_timestamp = time.time()
         self._log = logging.getLogger(f'{__name__}.{self.__class__.__qualname__}')
 
-        super().__init__(name='EplusSessionUpdater', daemon=True)
+        super().__init__(name=self.__class__.__qualname__, daemon=True)
 
     def close(self):
         if self._closed.is_set():

--- a/eplus.py
+++ b/eplus.py
@@ -159,25 +159,7 @@ class EplusHLSStreamWorker(HLSStreamWorker):
         self._eplus_url = eplus_url
 
     def reload_playlist(self):
-        try:
-            return super().reload_playlist()
-        except StreamError as err:
-            rerr = getattr(err, "err", None)
-            if (
-                self._eplus_url
-                and rerr is not None
-                and isinstance(rerr, HTTPError)
-                and rerr.response.status_code == 403
-            ):
-                log.debug("eplus auth rejected, refreshing session")
-                self.session.http.get(
-                    self._eplus_url,
-                    exception=StreamError,
-                    **self.reader.request_params,
-                )
-            else:
-                raise
-        return super().reload_playlist()
+        super().reload_playlist()
 
 
 class EplusHLSStreamReader(HLSStreamReader):

--- a/eplus.py
+++ b/eplus.py
@@ -71,9 +71,7 @@ class EplusSessionUpdater(Thread):
     def run(self):
         self._log.debug("Starting session updater...")
 
-        while True:
-            if self._closed.is_set():
-                return
+        while not self._closed.is_set():
 
             # Create a new session without cookies and send a request to Eplus url to obtain new cookies.
             self._log.debug("Refreshing cookies...")

--- a/eplus.py
+++ b/eplus.py
@@ -8,12 +8,14 @@ unsupported).
 import logging
 import html
 import re
+import time
+from threading import Thread, Event
 
 from requests.exceptions import HTTPError
 from streamlink.buffers import RingBuffer
 from streamlink.exceptions import StreamError
 from streamlink.plugin import Plugin
-from streamlink.plugin.api import validate, useragents
+from streamlink.plugin.api import validate, useragents, HTTPSession
 from streamlink.stream.hls import HLSStream, HLSStreamReader, HLSStreamWorker
 
 log = logging.getLogger(__name__)
@@ -35,6 +37,119 @@ def _get_eplus_data(session, eplus_url):
     if m:
         result["channel_url"] = m.group("channel_url").replace(r"\/", "/")
     return result
+
+
+class EplusSessionUpdater(Thread):
+    """
+    Cookies for Eplus expire after about 1 hour.
+    To keep our live streaming going, we have to refresh them in time,
+    otherwise we may got HTTP 403 and no new stream could be downloaded.
+    """
+
+    def __init__(self, session, eplus_url):
+        self._eplus_url = eplus_url
+        self._session = session
+        self._closed = Event()
+        self._retries = 0
+        self._last_expire_timestamp = time.time()
+
+        super().__init__(name='EplusSessionUpdater', daemon=True)
+
+    def close(self):
+        if self._closed.is_set():
+            """
+            "close(self)" will be called multiple times during the cleanup process of Streamlink.
+            If Python is about to exit, calling "log.debug()" will raise an exception:
+            > ImportError: sys.meta_path is None, Python is likely shutting down <
+            """
+            return
+
+        log.debug('[EplusSessionUpdater] Closing session updater...')
+        self._closed.set()
+
+    def run(self):
+        log.debug('[EplusSessionUpdater] Starting session updater...')
+
+        while True:
+            if self._closed.is_set():
+                return
+
+            # Create a new session without cookies and send a request to Eplus url to obtain new cookies.
+            log.debug('[EplusSessionUpdater] Refreshing cookies...')
+            try:
+                fresh_response = self._session_duplicator().get(self._eplus_url)
+                log.debug(f'[EplusSessionUpdater] Got new cookies: {repr(fresh_response.cookies)}')
+
+                # Filter cookies.
+                # For now, only the "ci_session" cookie is what we don't need, so ignore it.
+                cookie = next(
+                    cookie for cookie in fresh_response.cookies
+                        if cookie.name != 'ci_session'
+                        and cookie.expires > time.time()
+                )
+                log.debug(
+                    '[EplusSessionUpdater] Found a valid cookie that will expire at '
+                    f'{time.strftime(r"%Y%m%d-%H%M%S%z", time.localtime(cookie.expires))}. '
+                    f'The cookie: {repr(cookie)}'
+                )
+
+                # Update the global session with the new cookies.
+                self._session.http.cookies.clear()
+                self._session.http.cookies.update(fresh_response.cookies)
+
+                self._retries = 0
+                self._last_expire_timestamp = cookie.expires
+
+                # Refresh cookies at most 5 minutes before expiration.
+                wait_sec = (cookie.expires - 5 * 60) - time.time()
+                if wait_sec < 0:
+                    # It's too close! Retry it right away.
+                    wait_sec = 0
+
+                log.debug(
+                    '[EplusSessionUpdater] Refreshed cookies. Next attempt will be at about '
+                    f'{time.strftime(r"%Y%m%d-%H%M%S%z", time.localtime(time.time() + wait_sec))}. '
+                )
+
+                self._closed.wait(wait_sec)
+                continue
+
+            except StopIteration as e:
+                # next() exhausted all cookies.
+                log.error('[EplusSessionUpdater] No valid cookies found.')
+
+            except Exception as e:
+                log.error(f'[EplusSessionUpdater] Failed to refresh cookies: {e}')
+
+            self._retries += 1
+            retry_delay_sec = 2 ** (self._retries - 1)
+
+            if time.time() + retry_delay_sec > self._last_expire_timestamp + 1 * 60 * 60:
+                log.error('[EplusSessionUpdater] We have not refreshed cookies in the past hour and will not try again.')
+
+                self.close()
+                return
+
+            log.debug(f'[EplusSessionUpdater] We will retry in {retry_delay_sec}s.')
+
+            self._closed.wait(retry_delay_sec)
+            continue
+
+    def _session_duplicator(self):
+        """
+        Make a duplicate of the member "_session" except for cookies.
+        """
+
+        new_session = HTTPSession()
+
+        new_session.proxies = self._session.http.proxies
+        new_session.headers = self._session.http.headers
+        new_session.trust_env = self._session.http.trust_env
+        new_session.verify = self._session.http.verify
+        new_session.cert = self._session.http.cert
+        new_session.timeout = self._session.http.timeout
+
+        return new_session
 
 
 class EplusHLSStreamWorker(HLSStreamWorker):
@@ -70,6 +185,7 @@ class EplusHLSStreamReader(HLSStreamReader):
     def __init__(self, *args, eplus_url=None, **kwargs):
         super().__init__(*args, **kwargs)
         self._eplus_url = eplus_url
+        self.session_updater = EplusSessionUpdater(session=self.session, eplus_url=eplus_url)
 
     def open(self):
         buffer_size = self.session.get_option("ringbuffer-size")
@@ -79,6 +195,11 @@ class EplusHLSStreamReader(HLSStreamReader):
 
         self.writer.start()
         self.worker.start()
+        self.session_updater.start()
+
+    def close(self):
+        super().close()
+        self.session_updater.close()
 
 
 class EplusHLSStream(HLSStream):

--- a/eplus.py
+++ b/eplus.py
@@ -152,9 +152,8 @@ class EplusSessionUpdater(Thread):
 
 
 class EplusHLSStreamWorker(HLSStreamWorker):
-    def __init__(self, *args, eplus_url=None, **kwargs):
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._eplus_url = eplus_url
 
     def reload_playlist(self):
         super().reload_playlist()
@@ -172,7 +171,7 @@ class EplusHLSStreamReader(HLSStreamReader):
         buffer_size = self.session.get_option("ringbuffer-size")
         self.buffer = RingBuffer(buffer_size)
         self.writer = self.__writer__(self)
-        self.worker = self.__worker__(self, eplus_url=self._eplus_url)
+        self.worker = self.__worker__(self)
 
         self.writer.start()
         self.worker.start()


### PR DESCRIPTION
# Hello

This PR is a rewrite for #10 (especially, the part that contains the "```EplusSessionUpdater```" class).

All ideas from @ipid about automatically updating cookies have been implemented and re-implemented.

All suggestions from @pmrowla in the code review of #10 have been applied.

# Features

Copied from the commit message:

1. Try to get new cookies by a new "```HTTPSession()```" object in a separate thread.
2. The time for the next attempt to refresh cookies is determined by the expiration time of the previously obtained cookies.
3. Limited retries with binary exponential backoff if error occurred.

# The thing could be improved in the future

Try to add the "\[EplusSessionUpdater\]" prefix to the logger within the "```EplusSessionUpdater```" class. Manually adding that prefix to log messages makes the code long and redundant.

# Test logs

The following content may not represent the actual output since I have not finished this PR before my Eplus link expired.

For the sake of readability, both "```[plugins.eplus]```" and "```[EplusSessionUpdater]```" prefixes are omitted.

- Before applying this PR, we cannot continuously watch even a 61-minute live streaming:

```
...
[cli][info] Found matching plugin eplus for URL https://live.eplus.jp/ex/player?ib=
...
[cli][info] Opening stream:
[stream.hls][debug] Reloading playlist
...
... two thousand years later ...
...
[stream.hls][error] Failed to fetch segment ...: Unable to open URL: https://vod.live.eplus.jp/.../....ts (403 Client Error: Forbidden for url: ...)
[stream.hls][error] Failed to fetch segment ...: Unable to open URL: https://vod.live.eplus.jp/.../....ts (403 Client Error: Forbidden for url: ...)
[stream.hls][error] Failed to fetch segment ...: Unable to open URL: https://vod.live.eplus.jp/.../....ts (403 Client Error: Forbidden for url: ...)
...
error: Error when reading from stream: Read timeout, exiting
[stream.segmented][debug] Closing worker thread
[stream.segmented][debug] Closing writer thread
[cli][info] Stream ended
[cli][info] Closing currently open stream...
...

```

- After loading our "```EplusSessionUpdater```":

```
...
[cli][info] Found matching plugin eplus for URL https://live.eplus.jp/ex/player?ib=
...
[cli][info] Opening stream:
[stream.hls][debug] Reloading playlist
[debug] Starting session updater...
[debug] Refreshing cookies...
...
[debug] Got new cookies: <RequestsCookieJar[...]>
[debug] Found a valid cookie that will expire at 20090214-052000+0800. The cookie: Cookie(..., name='CloudFront-Key-Pair-Id', ..., expires=1234560000, ...)
[debug] Refreshed cookies. Next attempt will be at about 20090214-051500+0800.
...
[debug] Refreshing cookies...
[debug] Got new cookies: <RequestsCookieJar[...]>
[debug] Found a valid cookie that will expire at 20090214-061500+0800. The cookie: Cookie(..., name='CloudFront-Key-Pair-Id', ..., expires=1234563300, ...)
[debug] Refreshed cookies. Next attempt will be at about 20090214-061000+0800.
...
[debug] Refreshing cookies...
[debug] Got new cookies: <RequestsCookieJar[...]>
[debug] Found a valid cookie that will expire at 20090214-071000+0800. The cookie: Cookie(..., name='CloudFront-Key-Pair-Id', ..., expires=1234566600, ...)
[debug] Refreshed cookies. Next attempt will be at about 20090214-070500+0800.
...
[stream.segmented][debug] Closing writer thread
[debug] Closing session updater...
[cli][info] Stream ended
[cli][info] Closing currently open stream...
...

```

- If Eplus gave us invalid cookies (outdated or incomplete):

```
...
[debug] Starting session updater...
[debug] Refreshing cookies...
...
[debug] Got new cookies: <RequestsCookieJar[...]>
[error] No valid cookies found.
[debug] We will retry in 1s.
...
[debug] Refreshing cookies...
[debug] Got new cookies: <RequestsCookieJar[...]>
[error] No valid cookies found.
[debug] We will retry in 2s.
...
[debug] Refreshing cookies...
[debug] Got new cookies: <RequestsCookieJar[...]>
[error] No valid cookies found.
[debug] We will retry in 4s.
...
[debug] Refreshing cookies...
[debug] Got new cookies: <RequestsCookieJar[...]>
[error] No valid cookies found.
[error] We have not refreshed cookies in the past hour and will not try again.
[debug] Closing session updater...
...

```

- If something bad happened (e.g., got a wrong Eplus url):

```
...
[debug] Starting session updater...
[debug] Refreshing cookies...
...
[error] Failed to refresh cookies: ...
[debug] We will retry in 1s.
...
[debug] Refreshing cookies...
[error] Failed to refresh cookies: ...
[debug] We will retry in 2s.
...
[debug] Refreshing cookies...
[error] Failed to refresh cookies: ...
[debug] We will retry in 4s.
...
[debug] Refreshing cookies...
[error] Failed to refresh cookies: ...
[error] We have not refreshed cookies in the past hour and will not try again.
[debug] Closing session updater...
...

```

EOF
