### PR TITLE
eplus: gracefully shutdown when live ends (rewrite)

### DIFF
--- a/eplus.py
+++ b/eplus.py
@@ -171,20 +171,12 @@ class EplusHLSStreamWorker(HLSStreamWorker):
         """
         if self.playlist_changed:
             self._playlist_changed_timestamp = time.time()
+        elif (time.time() - self._playlist_changed_timestamp) > self._playlist_unchanged_timeout:
             self._log.debug(
-                "Playlist has been changed at "
-                f"{time.strftime(r'%Y%m%d-%H%M%S%z', time.localtime(self._playlist_changed_timestamp))} "
-                f"({self._playlist_changed_timestamp}). "
+                f"The {self._playlist_unchanged_timeout}-second timeout reached, "
+                "this is the last playlist. "
             )
-        else:
-            if (time.time() - self._playlist_changed_timestamp) > self._playlist_unchanged_timeout:
-                self._log.debug(
-                    f"The {self._playlist_unchanged_timeout}-second timeout reached, "
-                    "this is the last playlist. "
-                )
-                self.close()
-            else:
-                self._log.debug("Playlist was unchanged, continue waiting...")
+            self.close()
 
 
 class EplusHLSStreamReader(HLSStreamReader):


### PR DESCRIPTION
Hi! This PR is a rewrite for #10 (especially, the part that contains the "reload_playlist" function).

All ideas from @ipid about checking the timeout of playlists have been re-implemented.

## What's wrong

I tried to pipe the stream from Streamlink to FFmpeg to transcode, but I always got an "```av_interleaved_write_frame(): Broken pipe```" error from FFmpeg after the live streaming was over. Using Stramlink alone was also unlucky since it always exited with a non-zero code. It's annoying that I've written the code to check the exit code, so subsequent commands cannot be executed.

This problem didn't appear when I was working with VoD streams.

Here is the log from Streamlink when piping the stream to stdout:

<details open>
<summary>"Read timeout" after "Reloading playlist" in Streamlink log</summary>

```console
[21:15:45.7][stream.hls][debug] Reloading playlist
[21:15:45.7][cli][debug] Pre-buffering 8192 bytes
[21:15:45.7][stream.hls][debug] First Sequence: 7167; Last Sequence: 7176
[21:15:45.7][stream.hls][debug] Start offset: 0; Duration: None; Start Sequence: 7174; End Sequence: None
[21:15:45.8][stream.hls][debug] Adding segment 7174 to queue
[21:15:45.8][stream.hls][debug] Adding segment 7175 to queue
[21:15:45.8][stream.hls][debug] Adding segment 7176 to queue
[21:15:45.8][cli][debug] Writing stream to output
[21:15:45.9][stream.hls][debug] Segment 7174 complete
[21:15:46.0][stream.hls][debug] Segment 7175 complete
[21:15:46.1][stream.hls][debug] Segment 7176 complete
[21:15:52.8][stream.hls][debug] Reloading playlist
[21:15:52.8][stream.hls][debug] Adding segment 7177 to queue
[21:15:52.8][stream.hls][debug] Adding segment 7178 to queue
[21:15:52.9][stream.hls][debug] Segment 7177 complete
[21:15:53.3][stream.hls][debug] Segment 7178 complete
[21:15:59.8][stream.hls][debug] Reloading playlist
...
[23:41:25.6][stream.hls][debug] Reloading playlist
[23:41:25.7][stream.hls][debug] Adding segment 9931 to queue
[23:41:25.7][stream.hls][debug] Adding segment 9932 to queue
[23:41:25.7][stream.hls][debug] Segment 9931 complete
[23:41:26.0][stream.hls][debug] Segment 9932 complete
[23:41:32.7][stream.hls][debug] Reloading playlist
[23:41:32.7][stream.hls][debug] Adding segment 9933 to queue
[23:41:33.0][stream.hls][debug] Segment 9933 complete
[23:41:39.7][stream.hls][debug] Reloading playlist
[23:41:43.3][stream.hls][debug] Reloading playlist
[23:41:46.9][stream.hls][debug] Reloading playlist
[23:41:50.5][stream.hls][debug] Reloading playlist
[23:41:54.0][stream.hls][debug] Reloading playlist
[23:41:57.5][stream.hls][debug] Reloading playlist
[23:42:01.1][stream.hls][debug] Reloading playlist
[23:42:04.6][stream.hls][debug] Reloading playlist
[23:42:08.2][stream.hls][debug] Reloading playlist
[23:42:11.8][stream.hls][debug] Reloading playlist
[23:42:15.3][stream.hls][debug] Reloading playlist
[23:42:18.9][stream.hls][debug] Reloading playlist
[23:42:22.4][stream.hls][debug] Reloading playlist
[23:42:26.0][stream.hls][debug] Reloading playlist
[23:42:29.5][stream.hls][debug] Reloading playlist
error: Error when reading from stream: Read timeout, exiting
[23:42:33.0][stream.segmented][debug] Closing worker thread
[23:42:33.0][stream.segmented][debug] Closing writer thread
[23:42:33.0][cli][info] Stream ended
[23:42:33.0][cli][info] Closing currently open stream...

```

</details>

## Analysis

### Reason for the error

After reading the source code, we know that the "Read timeout" error comes from the "[```RingBuffer::read()```](https://github.com/streamlink/streamlink/blob/4.2.0/src/streamlink/buffers.py#L104-L109)" function, which is called by "[```SegmentedStreamReader::read()```](https://github.com/streamlink/streamlink/blob/4.2.0/src/streamlink/stream/segmented.py#L239-L244)". The reader was waiting for the writer to write streams into the buffer, but unfortunately there didn't seem to be any new data. What happened at the end of the live?

I've dumped almost all ".m3u8" playlists from a live and finally got the point. The following is part of the content:

<table>
<thead>
  <tr>
    <th>Index</th>
    <th>n-42</th>
    <th>...</th>
    <th>n-2</th>
    <th>n-1</th>
    <th>n</th>
  </tr>
</thead>
<tbody>
  <tr>
    <td>".m3u8" content</td>
    <td><pre>
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-TARGETDURATION:7
#EXT-X-MEDIA-SEQUENCE:1234
#EXT-X-DISCONTINUITY-SEQUENCE:36
#EXT-X-PROGRAM-DATE-TIME:00:56:55.844Z
#EXTINF:6.006,
index_0_1234.ts
#EXTINF:6.006,
index_0_1235.ts
#EXTINF:6.006,
index_0_1236.ts
#EXTINF:6.006,
index_0_1237.ts
#EXTINF:6.006,
index_0_1238.ts
#EXTINF:6.006,
index_0_1239.ts
#EXTINF:6.006,
index_0_1240.ts
#EXTINF:6.006,
index_0_1241.ts
#EXTINF:6.006,
index_0_1242.ts
#EXTINF:6.006,
index_0_1243.ts
    </pre></td>
    <td>...</td>
    <td><pre>
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-TARGETDURATION:7
#EXT-X-MEDIA-SEQUENCE:5676
#EXT-X-DISCONTINUITY-SEQUENCE:36
#EXT-X-PROGRAM-DATE-TIME:23:08:45.746Z
#EXTINF:6.006,
index_0_5676.ts
#EXTINF:6.006,
index_0_5677.ts
#EXTINF:6.006,
index_0_5678.ts
#EXTINF:6.006,
index_0_5679.ts
#EXTINF:6.006,
index_0_5680.ts
#EXTINF:6.006,
index_0_5681.ts
#EXTINF:6.006,
index_0_5682.ts
#EXTINF:6.006,
index_0_5683.ts
#EXTINF:6.006,
index_0_5684.ts
#EXTINF:6.006,
index_0_5685.ts
    </pre></td>
    <td><pre>
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-TARGETDURATION:7
#EXT-X-MEDIA-SEQUENCE:5678
#EXT-X-DISCONTINUITY-SEQUENCE:36
#EXT-X-PROGRAM-DATE-TIME:23:08:57.758Z
#EXTINF:6.006,
index_0_5678.ts
#EXTINF:6.006,
index_0_5679.ts
#EXTINF:6.006,
index_0_5680.ts
#EXTINF:6.006,
index_0_5681.ts
#EXTINF:6.006,
index_0_5682.ts
#EXTINF:6.006,
index_0_5683.ts
#EXTINF:6.006,
index_0_5684.ts
#EXTINF:6.006,
index_0_5685.ts
#EXTINF:6.006,
index_0_5686.ts
#EXTINF:6.006,
index_0_5687.ts
    </pre></td>
    <td><pre>
#EXTM3U
#EXT-X-VERSION:3
#EXT-X-TARGETDURATION:7
#EXT-X-MEDIA-SEQUENCE:5678
#EXT-X-DISCONTINUITY-SEQUENCE:36
#EXT-X-PROGRAM-DATE-TIME:23:08:57.758Z
#EXTINF:6.006,
index_0_5678.ts
#EXTINF:6.006,
index_0_5679.ts
#EXTINF:6.006,
index_0_5680.ts
#EXTINF:6.006,
index_0_5681.ts
#EXTINF:6.006,
index_0_5682.ts
#EXTINF:6.006,
index_0_5683.ts
#EXTINF:6.006,
index_0_5684.ts
#EXTINF:6.006,
index_0_5685.ts
#EXTINF:6.006,
index_0_5686.ts
#EXTINF:6.006,
index_0_5687.ts
    </pre></td>
  </tr>
</tbody>
</table>

As you can see, when the live was about to end, the playlist was no longer changed, so the "worker" of course cannot get any new streams. In addition, since there was not an "[```#EXT-X-ENDLIST```](https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.3.4)" tag in the last updated playlist (the "n-1" one), Streamlink would continuously wait for new data and finally got a timeout error.

If my guess is correct, these playlists are "[Live Playlists](https://datatracker.ietf.org/doc/html/rfc8216#section-6.2.2)" and should not contain the "```#EXT-X-ENDLIST```" tag before the live ends. Thus, the root problem is that the last updated playlist didn't comply with the standard (i.e., provided the "```#EXT-X-ENDLIST```" tag).

### How long is the timeout?

About "[```stream-timeout```](https://github.com/streamlink/streamlink/blob/4.2.0/src/streamlink_cli/argparser.py#L823-L834)" seconds.

### Why the interval of reloading playlists was changed from about 7 seconds to about 3.5 seconds?

The interval is "```self.playlist_reload_time```". It was 7 seconds ("```playlist.target_duration```", which is from "[```#EXT-X-TARGETDURATION```](https://datatracker.ietf.org/doc/html/rfc8216#section-4.3.3.1)") in "[```_playlist_reload_time()```](https://github.com/streamlink/streamlink/blob/4.2.0/src/streamlink/stream/hls.py#L334-L335)" and 3.5 seconds ("```max(self.playlist_reload_time / 2, 1)```") in "[```process_sequences()```](https://github.com/streamlink/streamlink/blob/4.2.0/src/streamlink/stream/hls.py#L350-L351)".

### What if Eplus finally had updated the playlist and provided an "```#EXT-X-ENDLIST```" tag?

If so, the "worker" would set "[```self.playlist_end```](https://github.com/streamlink/streamlink/blob/4.2.0/src/streamlink/stream/hls.py#L353-L354)" to the last sequence's index. However, if the updated playlist had not contained any new streams, the "[```self.valid_sequence```](https://github.com/streamlink/streamlink/blob/4.2.0/src/streamlink/stream/hls.py#L410)" filter in "```iter_segments()```" would prevent the "worker" from checking "```self.playlist_end```" and then let the playlist be reloaded like before.

## Solution

We can determine whether the live has ended based on whether the playlist is still changing. In the "```HLSStreamWorker```" class, we have the "```playlist_changed```" member and it will be updated in the "[```process_sequences()```](https://github.com/streamlink/streamlink/blob/4.2.0/src/streamlink/stream/hls.py#L347)" function. In this PR, we think that if the playlist remains unchanged for one half of "```stream-timeout```" seconds, the live has ended.

## Test

```console
[00:01:48.38] Reloading playlist
[00:01:48.41] Playlist has been changed at ...
[00:01:48.41] Adding segment 3333 to queue
[00:01:48.50] Segment 3333 complete
[00:01:55.41] Reloading playlist
[00:01:55.53] Playlist has been changed at ...
[00:01:55.53] Adding segment 3334 to queue
[00:01:55.53] Adding segment 3335 to queue
[00:01:55.87] Segment 3334 complete
[00:01:56.17] Segment 3335 complete
[00:02:02.53] Reloading playlist
[00:02:03.45] Playlist has been changed at ...
[00:02:03.45] Adding segment 3336 to queue
[00:02:03.80] Segment 3336 complete
[00:02:10.45] Reloading playlist
[00:02:10.57] Playlist was unchanged, continue waiting...
[00:02:14.07] Reloading playlist
[00:02:14.21] Playlist was unchanged, continue waiting...
[00:02:17.71] Reloading playlist
[00:02:17.75] Playlist was unchanged, continue waiting...
...
[00:02:35.25] Reloading playlist
[00:02:35.35] The 30.0-second timeout reached, this is the last playlist. 
[00:02:35.35] Closing worker thread
[00:02:35.35] Closing writer thread
[00:02:35.35] Closing session updater...
[00:02:35.36][cli][info] Stream ended
[00:02:35.36][cli][info] Closing currently open stream...

```

EOF
