### PR TITLE
fix: "Plugin.can_handle_url" has been deprecated since Streamlink 2.3.0

### DIFF
--- a/eplus.py
+++ b/eplus.py
@@ -14,7 +14,7 @@ from threading import Thread, Event
 from requests.exceptions import HTTPError
 from streamlink.buffers import RingBuffer
 from streamlink.exceptions import StreamError
-from streamlink.plugin import Plugin
+from streamlink.plugin import Plugin, pluginmatcher
 from streamlink.plugin.api import validate, useragents, HTTPSession
 from streamlink.stream.hls import HLSStream, HLSStreamReader, HLSStreamWorker
 
@@ -216,11 +216,13 @@ class EplusHLSStream(HLSStream):
         return reader
 
 
+# https://live.eplus.jp/ex/player?ib=<key>
+# key is base64-encoded 64 byte unique key per ticket
+@pluginmatcher(re.compile(
+    r"https://live\.eplus\.jp/ex/player\?ib=.+"
+))
 class Eplus(Plugin):
 
-    # https://live.eplus.jp/ex/player?ib=<key>
-    # key is base64-encoded 64 byte unique key per ticket
-    _URL_RE = re.compile(r"https://live\.eplus\.jp/ex/player\?ib=.+")
     _ORIGIN = "https://live.eplus.jp"
     _REFERER = "https://live.eplus.jp/"
 
@@ -234,10 +236,6 @@ class Eplus(Plugin):
             }
         )
         self.title = None
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return cls._URL_RE.match(url) is not None
 
     def get_title(self):
         return self.title

--- a/nhltv.py
+++ b/nhltv.py
@@ -7,7 +7,7 @@ import time
 
 import requests.cookies
 
-from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError
+from streamlink.plugin import Plugin, PluginArgument, PluginArguments, PluginError, pluginmatcher
 from streamlink.plugin.api import useragents
 from streamlink.stream import HLSStream
 
@@ -49,7 +49,6 @@ NHL_TEAMS = {
 }
 
 
-_URL_RE = re.compile(r"https://www.nhl.com/tv/(?P<game_pk>\d+)")
 _STATS_API_URL = "https://statsapi.web.nhl.com/api/v1"
 _MEDIA_API_URL = "https://mf.svc.nhl.com/ws/media/mf/v2.4"
 _LOGIN_URL = "https://gateway.web.nhl.com/ws/subscription/flow/nhlPurchase.login"
@@ -61,6 +60,9 @@ def now_ms():
     return int(round(time.time() * 1000))
 
 
+@pluginmatcher(re.compile(
+    r"https://www.nhl.com/tv/(?P<game_pk>\d+)"
+))
 class NHLTV(Plugin):
 
     NATIONAL_WEIGHT = 4
@@ -116,13 +118,8 @@ class NHLTV(Plugin):
                 "User-Agent": useragents.CHROME,
             }
         )
-        match = _URL_RE.match(url).groupdict()
-        self.game_pk = match.get("game_pk")
+        self.game_pk = self.match.group("game_pk")
         self.prefer_team = None
-
-    @classmethod
-    def can_handle_url(cls, url):
-        return _URL_RE.match(url) is not None
 
     @classmethod
     def stream_weight(cls, key):


### PR DESCRIPTION
Long time no see!

Simple URL match test:

```console
# eplus
[cli][info] Found matching plugin eplus for URL https://live.eplus.jp/ex/player?ib=...
```

```console
# nhltv
[cli][info] Found matching plugin nhltv for URL https://www.nhl.com/tv/42
```

```console
# spwn
[cli][info] Found matching plugin spwn for URL https://spwn.jp/events/answer-is-42
```

Please see [streamlink 2.3.0 § Deprecations - Streamlink documentation](https://streamlink.github.io/deprecations.html#streamlink-2-3-0).