### PR TITLE
eplus: support account; refresh cookies within 15 mins; check "drm_mode"

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,12 @@ Alternatively, individual plugins can be symlinked or downloaded to `~/.config/s
 
 https://eplus.jp/ plugin.
 
-- Currently only supports direct `live.eplus.jp` (ticketed) stream or VOD URLs.
+- Supports `live.eplus.jp` (local) and `live.eplus.jp/ex/player?ib=` (inbound)
+  stream or VOD URLs.
+- Login required to view live event or VOD on `live.eplus.jp`. `--eplus-id`
+  and `--eplus-password` options can be used to specify login credentials.
+  Specifying `ci_session` cookie by `--http-cookie` option is another way to
+  access restricted content.
 - Streamlink will count as one (desktop browser) "device" against the e+ limit
   when viewing a stream or VOD.
 - `--player-passthrough=hls` is incompatible with e+ since the video player

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # streamlink-plugins
 
-Custom plugins for [Streamlink](https://github.com/streamlink/streamlink) 4.3.0 and newer versions.
+Custom plugins for [Streamlink](https://github.com/streamlink/streamlink) 5.5.0 and newer versions with Python 3.8 and newer version.
 
 To use these plugins, clone this repo somewhere and run (or configure) streamlink with `--plugin-dir`.
 Alternatively, individual plugins can be symlinked or downloaded to `~/.config/streamlink/plugins`

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ https://eplus.jp/ plugin.
   Specifying `ci_session` cookie by `--http-cookie` option is another way to
   access restricted content.
 - Streamlink will count as one (desktop browser) "device" against the e+ limit
-  when viewing a stream or VOD.
+  when viewing a stream or VOD. Set `--eplus-allow-relogin` to kick other
+  "devices" during download.
 - `--player-passthrough=hls` is incompatible with e+ since the video player
   will not have access to the authenticated HTTP session.
 - DRM-protected content is NOT supported. If you have been notified that an

--- a/eplus.py
+++ b/eplus.py
@@ -89,7 +89,7 @@ def _get_eplus_data(session, eplus_url):
 
     app_id = data_json["app_id"]
 
-    if 'ex/player?ib=' in eplus_url:
+    if "ex/player?ib=" in eplus_url:
         # Eplus inbound
         session_update_url = eplus_url
     else:

--- a/eplus.py
+++ b/eplus.py
@@ -42,6 +42,7 @@ def _get_eplus_data(session: HTTPSession, eplus_url: str):
         validate.none_or_all(
             validate.get("list_channels"),
             validate.parse_json(),
+            list,
         ),
     )
     schema_stream_session = validate.Schema(
@@ -84,6 +85,8 @@ def _get_eplus_data(session: HTTPSession, eplus_url: str):
         raise PluginError(f"Unknown delivery_status: {delivery_status}")
 
     m3u8_urls = schema_m3u8_urls.validate(body, "m3u8 urls")
+    if not m3u8_urls:
+        raise PluginError("Failed to get m3u8 urls")
 
     stream_session = schema_stream_session.validate(body, "stream_session")
     if not stream_session:

--- a/eplus.py
+++ b/eplus.py
@@ -398,6 +398,7 @@ class EplusHLSStream(HLSStream):
 @pluginargument(
     "password",
     metavar="PASSWORD",
+    sensitive=True,
     help="The password of your Eplus account",
 )
 @pluginargument(

--- a/eplus.py
+++ b/eplus.py
@@ -393,6 +393,7 @@ class EplusHLSStream(HLSStream):
 @pluginargument(
     "id",
     metavar="ID",
+    sensitive=True,
     help="The email address or mobile phone number associated with your Eplus account",
 )
 @pluginargument(

--- a/eplus.py
+++ b/eplus.py
@@ -170,7 +170,7 @@ class EplusSessionUpdater(Thread):
                     # It's too close! Retry it right away.
                     wait_sec = 0
                 elif wait_sec > 900:
-                    # Eplus local refresh the session within 15 minutes.
+                    # Eplus local refresh cookies within 15 minutes.
                     # The "expires" in the cookies should not be trusted.
                     wait_sec = 900
 

--- a/eplus.py
+++ b/eplus.py
@@ -8,13 +8,16 @@ import logging
 import re
 import time
 from threading import Thread, Event
-from typing import Dict, List
+from typing import Dict, List, Optional
 from urllib.parse import urlencode
 
 from streamlink.exceptions import NoStreamsError, PluginError
 from streamlink.plugin import Plugin, pluginargument, pluginmatcher
 from streamlink.plugin.api import validate, useragents
-from streamlink.session.http import HTTPSession
+try:
+    from streamlink.session.http import HTTPSession  # from 6.6.0
+except ImportError:
+    from streamlink.plugin.api import HTTPSession
 from streamlink.stream.hls import HLSStream, HLSStreamReader, HLSStreamWorker
 
 log = logging.getLogger(__name__)
@@ -367,7 +370,7 @@ class EplusHLSStreamReader(HLSStreamReader):
 class EplusHLSStream(HLSStream):
     __reader__ = EplusHLSStreamReader
 
-    _session_updater: EplusSessionUpdater | None
+    _session_updater: Optional[EplusSessionUpdater]
 
     @classmethod
     def parse_variant_playlist(cls, session, m3u8_url, eplus_data: EplusData):

--- a/eplus.py
+++ b/eplus.py
@@ -269,7 +269,7 @@ class EplusHLSStream(HLSStream):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.session_update_url = kwargs["session_update_url"]
+        self.session_update_url = None
 
     def open(self):
         reader = self.__reader__(self, session_update_url=self.session_update_url)
@@ -336,9 +336,11 @@ class Eplus(Plugin):
         #   multiple playlists, but multiple cameras in one video. That's an edited video so viewers
         #   cannot switch views.
         for channel_url in channel_urls:
-            yield from EplusHLSStream.parse_variant_playlist(
-                self.session, channel_url, session_update_url=session_update_url,
-            ).items()
+            for name, stream in EplusHLSStream.parse_variant_playlist(
+                self.session, channel_url
+            ).items():
+                stream.session_update_url = session_update_url
+                yield name, stream
 
     def _check_auth_status_and_try_login(self):
         self._log.info("Getting auth status")

--- a/eplus.py
+++ b/eplus.py
@@ -269,7 +269,7 @@ class EplusHLSStream(HLSStream):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.session_update_url = None
+        self.session_update_url = kwargs["session_update_url"]
 
     def open(self):
         reader = self.__reader__(self, session_update_url=self.session_update_url)
@@ -336,18 +336,16 @@ class Eplus(Plugin):
         #   multiple playlists, but multiple cameras in one video. That's an edited video so viewers
         #   cannot switch views.
         for channel_url in channel_urls:
-            for name, stream in EplusHLSStream.parse_variant_playlist(
-                self.session, channel_url
-            ).items():
-                stream.session_update_url = session_update_url
-                yield name, stream
+            yield from EplusHLSStream.parse_variant_playlist(
+                self.session, channel_url, session_update_url=session_update_url,
+            ).items()
 
     def _check_auth_status_and_try_login(self):
         self._log.info("Getting auth status")
 
         res = self.session.http.get(self.url)
         if res.url.startswith(self.url):
-            # already logged in
+            # already logged in or no login required
             return
 
         auth_url = res.url

--- a/eplus.py
+++ b/eplus.py
@@ -13,7 +13,8 @@ from urllib.parse import urlencode
 
 from streamlink.exceptions import NoStreamsError, PluginError
 from streamlink.plugin import Plugin, pluginargument, pluginmatcher
-from streamlink.plugin.api import validate, useragents, HTTPSession
+from streamlink.plugin.api import validate, useragents
+from streamlink.session.http import HTTPSession
 from streamlink.stream.hls import HLSStream, HLSStreamReader, HLSStreamWorker
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
## Test

Cookie:

```
[cli][debug] Arguments:
[cli][debug]  url=https://live.eplus.jp/1111111
[cli][debug]  stream=['worst']
[cli][debug]  --http-cookie=[('ci_session', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')]
[cli][info] Found matching plugin eplus for URL https://live.eplus.jp/1111111
[plugins.eplus.Eplus][info] Getting auth status
[plugins.eplus][debug] delivery_status = CONFIRMED_ARCHIVE, archive_mode = ON
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 240p (worst), 360p, 480p, 720p, 1080p (best)

```

ID and password:

```
[cli][debug] Arguments:
[cli][debug]  url=https://live.eplus.jp/1111111
[cli][debug]  stream=['worst']
[cli][debug]  --eplus-id=********
[cli][debug]  --eplus-password=********
[cli][info] Found matching plugin eplus for URL https://live.eplus.jp/1111111
[plugins.eplus.Eplus][info] Getting auth status
[plugins.eplus.Eplus][info] Sending pre-login info
[plugins.eplus.Eplus][info] Logging in via provided id and password
[plugins.eplus][debug] delivery_status = CONFIRMED_ARCHIVE, archive_mode = ON
[utils.l10n][debug] Language code: en_US
[cli][info] Available streams: 240p (worst), 360p, 480p, 720p, 1080p (best)

```

Please help me re-phrase the docs. :-)