### PR TITLE
spwn: log video_id camera name for multipart events

### DIFF
--- a/spwn.py
+++ b/spwn.py
@@ -309,6 +309,7 @@ class Spwn(Plugin):
         video_ids = sorted(stream_info.get("videoIds", []))
         for i, video_id in enumerate(video_ids, start=1):
             url = None
+            is_vod = False
             if self.options.get("low-latency"):
                 ll_cookie = cookies.get(video_id, {}).get("LL", {})
                 url = ll_cookie.get("url")
@@ -324,9 +325,9 @@ class Spwn(Plugin):
             except IndexError:
                 name = f"part{i}"
             if len(parts) > 1 or len(video_ids) > 1:
-                feed_path = self._get_feed_path(video_id, cookies)
-                feed_name = f": {feed_path}" if feed_path else ""
-                log.info(f"Multi-part event: {name} ({video_id}{feed_name})")
+                feed_name = self._get_feed_name(video_id, cookies)
+                feed_s = f": {feed_name}" if feed_name else ""
+                log.info(f"Multi-part event: {name} ({video_id}{feed_s})")
             if not url or (opt_id and video_id != opt_id):
                 continue
             yield VideoPart(
@@ -336,19 +337,26 @@ class Spwn(Plugin):
                 cookie,
             )
 
-    def _get_feed_path(self, video_id: str, cookies: dict[str, Any]) -> str | None:
+    def _get_feed_name(self, video_id: str, cookies: dict[str, Any]) -> str | None:
         # try to find camera/feed name via default cookie manifest URL
         url = cookies.get(video_id, {}).get("default", {}).get("url")
         if url:
+            is_vod = False
             parsed_url = urllib.parse.urlparse(url)
+            if parsed_url.hostname and "vod.spwn" in parsed_url.hostname:
+                is_vod = True
             path = PurePosixPath(urllib.parse.unquote(parsed_url.path))
             event_path: PurePosixPath | None = None
             for p in path.parents:
                 if p.name == self.id:
                     event_path = p
                     break
+            out: list[str] = []
             if event_path and path.parent != event_path:
-                return str(path.parent.relative_to(event_path))
+                out.append(str(path.parent.relative_to(event_path)))
+            if is_vod:
+                out.append("[VOD]")
+            return " ".join(out)
         return None
 
 __plugin__ = Spwn

--- a/spwn.py
+++ b/spwn.py
@@ -6,7 +6,9 @@ Requires valid SPWN account and event tickets.
 
 import logging
 import re
+import urllib.parse
 from datetime import datetime, timedelta
+from pathlib import PurePosixPath
 from typing import Any, Dict, NamedTuple
 
 import requests
@@ -322,7 +324,9 @@ class Spwn(Plugin):
             except IndexError:
                 name = f"part{i}"
             if len(parts) > 1 or len(video_ids) > 1:
-                log.info(f"Multi-part event: {name} ({video_id})")
+                feed_path = self._get_feed_path(video_id, cookies)
+                feed_name = f": {feed_path}" if feed_path else ""
+                log.info(f"Multi-part event: {name} ({video_id}{feed_name})")
             if not url or (opt_id and video_id != opt_id):
                 continue
             yield VideoPart(
@@ -332,5 +336,19 @@ class Spwn(Plugin):
                 cookie,
             )
 
+    def _get_feed_path(self, video_id: str, cookies: dict[str, Any]) -> str | None:
+        # try to find camera/feed name via default cookie manifest URL
+        url = cookies.get(video_id, {}).get("default", {}).get("url")
+        if url:
+            parsed_url = urllib.parse.urlparse(url)
+            path = PurePosixPath(urllib.parse.unquote(parsed_url.path))
+            event_path: PurePosixPath | None = None
+            for p in path.parents:
+                if p.name == self.id:
+                    event_path = p
+                    break
+            if event_path and path.parent != event_path:
+                return str(path.parent.relative_to(event_path))
+        return None
 
 __plugin__ = Spwn


### PR DESCRIPTION
Logs vod/stream manifest path for multipart events which should make figuring out which part is which easier since video id order is no longer reliable

```
streamlink https://spwn.jp/events/evt_26030601-jphololive7thfes          ⏎
[cli][info] Found matching plugin spwn for URL https://spwn.jp/events/evt_26030601-jphololive7thfes
[plugins.spwn][info] Logged into SPWN as ...
[plugins.spwn][info] Found SPWN event: hololive 7th fes. Ridin’ on Dreams
[plugins.spwn][info] Multi-part event: part1 (96Vc7ffuIoQrJrAfrg1p: rgrp5/stage3_v1 [VOD])
[plugins.spwn][info] Multi-part event: part2 (Aq2VHroWZwOOwJ8YMxkw)
[plugins.spwn][info] Multi-part event: part3 (R6XxHDpXT7zyCKr7516z: rgrp5/stage1_v1 [VOD])
[plugins.spwn][info] Multi-part event: part4 (dGIS635sOK6onrqUL64W: grpstage-2-1/cam1_v1 [VOD])
Available streams: part4_144p (worst), part1_144p, part3_144p, part4_240p, part1_240p, part3_240p, part4_360p, part1_360p, part3_360p, part4_480p, part1_480p, part3_480p, part4_720p, part1_720p, part3_720p, part4_1080p, part1_1080p, part3_1080p (best)
```

(`grpstage-2-1/...` is the Stage 2 VOD feed, not sure why it is named differently than Stage 1 & Stage 3)